### PR TITLE
Ticket4877 convert dbchecker python3

### DIFF
--- a/add_sim_records.py
+++ b/add_sim_records.py
@@ -2,36 +2,41 @@ import re
 import os
 import argparse
 from db_parser import parse_db
-from records import Record, Alias
-from grouper import Grouper, RecordGroup
+from grouper import Grouper
 import textwrap
 
-#Only add SIM fields if type is one of the following:
-ALLOWED_SIM_TYPES = ['ai', 'ao', 'bi', 'bo', 'mbbi', 'mbbo', 'stringin', 'stringout', 'longin', 'longout', 'waveform']
+# Only add SIM fields if type is one of the following:
+ALLOWED_SIM_TYPES = [
+    'ai', 'ao', 'bi', 'bo', 'mbbi', 'mbbo', 'stringin',
+    'stringout', 'longin', 'longout', 'waveform'
+]
+
 
 def find_macro(name):
     if name.find('$') != -1:
         left = name.rfind(')') + 1
         macro = name[:left]
         pvname = name[left:]
-        return (macro, pvname)
+        return macro, pvname
     return None
+
 
 def get_sim_name(name):
     ans = find_macro(name)
     
-    if not ans is None:
+    if ans is not None:
         macro = ans[0]
         pvname = ans[1]
-        #Check for leading :
-        #eg. PV name was something like $(P):TEMP rather than $(P)TEMP
+        # Check for leading :
+        # e.g. PV name was something like $(P):TEMP rather than $(P)TEMP
         if pvname.startswith(':'):
             pvname = pvname[1:]
             macro += ':'
         return macro + "SIM:" + pvname
     else:
         return "SIM:" + pvname
-        
+
+
 def add_waveform_specfic(nelm, ftvl):
     str = ''
     if not(nelm is None) or nelm == "":
@@ -39,6 +44,7 @@ def add_waveform_specfic(nelm, ftvl):
     if not(ftvl is None) or ftvl == "":
         str += '    field(FTVL, "' + ftvl + '")\n'
     return str    
+
 
 def generate_single_record(original_record, name):
     return textwrap.dedent("""\
@@ -49,6 +55,7 @@ def generate_single_record(original_record, name):
         }}
         
         """.format(original_record.type, name, add_waveform_specfic(original_record.nelm, original_record.ftvl)))
+
 
 def generate_record_text(record, rb, sp, sp_rbv): 
     str = ''
@@ -71,14 +78,15 @@ def generate_record_text(record, rb, sp, sp_rbv):
             sp_rbv = get_sim_name(sp_rbv)
             str += 'alias("'+ sp + '","' + sp_rbv + '")' + '\n' + '\n'
     elif sp_rbv != '':
-        #Cannot think of any reason why a SP:RBV would exist on its own...
+        # Cannot think of any reason why a SP:RBV would exist on its own...
         sp_rbv = get_sim_name(sp_rbv)
         str += generate_single_record(record, sp_rbv)
         
     return str
 
+
 def find_common_macro(records):
-    #Find the most common macro name and whether it is followed by a colon
+    # Find the most common macro name and whether it is followed by a colon
     macros = {}
     for r in records:
         m, pv = find_macro(records[r].name)
@@ -92,7 +100,8 @@ def find_common_macro(records):
             best = m
     return best, macros[best][1]
 
-def generate_sim_records(records, sim_record_name, dis_record_name):      
+
+def generate_sim_records(records, sim_record_name, dis_record_name):
     sim_prefix = sim_record_name + ':'
     
     grouper = Grouper()
@@ -103,36 +112,44 @@ def generate_sim_records(records, sim_record_name, dis_record_name):
     for g in groups.keys():
         sim_record_name = get_sim_name(groups[g].main)
         
-        #Check sim record does not already exist - maybe someone started writing the records but got bored!
+        # Check sim record does not already exist - maybe someone
+        # started writing the records but got bored!
         if sim_record_name in records:
             continue
             
-        #Skip record if it is a simulation record 
+        # Skip record if it is a simulation record
         if groups[g].main.startswith(sim_prefix):
             continue
             
-        #Skip adding sim record if the original is a soft record
-        if records[groups[g].main].dtyp is None or records[groups[g].main].dtyp.lower() == "soft channel":
+        # Skip adding sim record if the original is a soft record
+        if records[groups[g].main].dtyp is None or \
+                records[groups[g].main].dtyp.lower() == "soft channel":
             continue
 
-        #No point simulating SIM or DISABLE
+        # No point simulating SIM or DISABLE
         if groups[g].RB != sim_record_name and groups[g].RB != dis_record_name:
             typ = records[groups[g].main].type
-            #Don't add simulation record unless the type is suitable
+            # Don't add simulation record unless the type is suitable
             if typ in ALLOWED_SIM_TYPES:            
                 print ("ADDED SIM RECORD = " + sim_record_name)
-                output += generate_record_text(records[groups[g].main], groups[g].RB, groups[g].SP, groups[g].SP_RBV)
+                output += generate_record_text(
+                    records[groups[g].main], groups[g].RB,
+                    groups[g].SP, groups[g].SP_RBV
+                )
                 
     return output
 
-def generate_modifed_db(file_in_path, file_out_path="generated.db", records={}, insert_sims=True, insert_disable=True):
-    record_start_regex = 'record\((\w+),\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
 
-    with open(file_in_path, 'r') as in_file, open(file_out_path, 'w') as out_file:
+def generate_modifed_db(file_in_path, file_out_path="generated.db",
+                        records={}, insert_sims=True, insert_disable=True):
+    record_start_regex = r'record\((\w+),\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
+
+    with open(file_in_path, 'r') as in_file, \
+            open(file_out_path, 'w') as out_file:
         prefix, colon = find_common_macro(records)
         if colon:
             prefix += ':'
-        print ("COMMON PREFIX = " + prefix)
+        print("COMMON PREFIX = " + prefix)
 
         sim_record_name = prefix + "SIM"
         dis_record_name = prefix + "DISABLE"
@@ -169,29 +186,43 @@ def generate_modifed_db(file_in_path, file_out_path="generated.db", records={}, 
                 if re.match("}$", line.strip()) is not None:
                     # Found end, insert sim and dis if necessary
 
-                    # Only add SIM and SDIS to allowed records which has a record type which is not soft channel
-                    if curr_record.type in ALLOWED_SIM_TYPES and curr_record.dtyp is not None and curr_record.dtyp.lower() != "soft channel":
-                            if insert_sims and curr_record.siml is None:
-                                name = get_sim_name(curr_record.name)
-                                out_file.write('    field(SIML, "' + sim_record_name +'")\n')
-                                out_file.write('    field(SIOL, "' + name+ '")\n')
-                            if insert_disable and curr_record.sdis is None:
-                                out_file.write('    field(SDIS, "' + dis_record_name +'")\n')
+                    # Only add SIM and SDIS to allowed records which has
+                    # a record type which is not soft channel
+                    if curr_record.type in ALLOWED_SIM_TYPES and \
+                            curr_record.dtyp is not None and \
+                            curr_record.dtyp.lower() != "soft channel":
+                        if insert_sims and curr_record.siml is None:
+                            name = get_sim_name(curr_record.name)
+                            out_file.write(
+                                '    field(SIML, "' + sim_record_name +'")\n'
+                            )
+                            out_file.write('    field(SIOL, "' + name + '")\n')
+                        if insert_disable and curr_record.sdis is None:
+                            out_file.write(
+                                '    field(SDIS, "' + dis_record_name + '")\n'
+                            )
             out_file.write(line)
 
         if insert_sims:
-            new_records = generate_sim_records(records, sim_record_name, dis_record_name)
+            new_records = generate_sim_records(
+                records, sim_record_name, dis_record_name
+            )
 
-            #If no new records, don't write anything
+            # If no new records, don't write anything
             if new_records.strip() != "":
                 out_file.write("\n### SIMULATION RECORDS ###\n\n")
                 out_file.write(new_records)
-    
-    
+
+
 if __name__ == '__main__':   
     parser = argparse.ArgumentParser()
-    parser.add_argument('file', nargs=1, type=str, help='The base file for adding records to')
-    parser.add_argument('-o', '--output',  nargs=1, default=[], help='The name of the output file')
+    parser.add_argument(
+        'file', nargs=1, type=str, help='The base file for adding records to'
+    )
+    parser.add_argument(
+        '-o', '--output',  nargs=1, default=[],
+        help='The name of the output file'
+    )
     args = parser.parse_args()
     
     file = args.file[0]  

--- a/add_sim_records_tests/test_db.db
+++ b/add_sim_records_tests/test_db.db
@@ -28,7 +28,7 @@ record(bo, "$(P)OUTPUT1:STATUS:SP")
     field(DTYP, "stream")
     field(OUT,  "@devAFG3XXX.proto setStatus(1) $(PORT)")
     field(ZNAM, "OFF")
-    field(ONAM, "ON")	
+    field(ONAM, "ON")
 }
 
 alias("$(P)OUTPUT1:STATUS", "$(P)OUTPUT1:STATUS:SP:RBV")

--- a/check_db_file.py
+++ b/check_db_file.py
@@ -4,8 +4,8 @@ import glob
 from db_checker import DbChecker
 
 
-def check_files(files, verbose):
-    for f in files:
+def check_files(db_files, verbose):
+    for f in db_files:
         try:
             fp = os.path.abspath(f)
             dbc = DbChecker(fp, verbose)
@@ -16,10 +16,20 @@ def check_files(files, verbose):
 
 if __name__ == '__main__':   
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--directory', nargs=1, default=[], help='The directory to search for db files in')
-    parser.add_argument('-f', '--files',  nargs='*', default=[], help='The db file(s) to test')
-    parser.add_argument('-r', '--recursive', action='store_true', help='Check all db files below the specified directory')
-    parser.add_argument('-v', '--verbose', action='store_true', help='Run in verbose mode')
+    parser.add_argument(
+        '-d', '--directory', nargs=1, default=[],
+        help='The directory to search for db files in'
+    )
+    parser.add_argument(
+        '-f', '--files',  nargs='*', default=[],
+        help='The db file(s) to test')
+    parser.add_argument(
+        '-r', '--recursive', action='store_true',
+        help='Check all db files below the specified directory'
+    )
+    parser.add_argument(
+        '-v', '--verbose', action='store_true', help='Run in verbose mode'
+    )
     args = parser.parse_args()
     
     if len(args.directory) == 0 and len(args.files) == 0:
@@ -36,7 +46,7 @@ if __name__ == '__main__':
                             tocheck.append(os.path.join(root, file))
                 check_files(tocheck, args.verbose)
             else:
-                #Find db files in directory
+                # Find db files in directory
                 os.chdir(args.directory[0])
                 files = glob.glob("*.db")
                 check_files(files, args.verbose)

--- a/db_checker.py
+++ b/db_checker.py
@@ -27,7 +27,7 @@ class DbChecker:
         self.debug = debug
         
     def check(self):
-        print("\n** CHECKING", self.file, "**")
+        print("\n** CHECKING {} **".format(self.file))
         records = parse_db(self.file)
         grouper = Grouper()
         
@@ -68,8 +68,8 @@ class DbChecker:
         for e in self.errors:
             print(e)
                                 
-        print("** WARNING COUNT =", len(self.warnings), "**")
-        print("** ERROR COUNT =", len(self.errors), "**")
+        print("** WARNING COUNT = {} **".format(len(self.warnings)))
+        print("** ERROR COUNT = {}".format(len(self.errors)))
         
     def remove_macro(self, pvname, remove_colon=True):
         if pvname.find('$') != -1:

--- a/db_checker.py
+++ b/db_checker.py
@@ -1,19 +1,23 @@
 import re
 from db_parser import parse_db
-from records import Record, Alias
-from grouper import Grouper, RecordGroup
+from records import Alias
+from grouper import Grouper
 
-#Rules implemented:
+# Rules implemented:
 # 1) Name should be uppercase
 # 2) Colons are used as main separator
 # 3) Names only use alphanumerics, underscore and colon
 # 4) Adheres to :SP and SP:RBV format
-# 5) If DUMMYPV and DUMMYPV:SP exists then DUMMYPV:SP:RBV should exist too (DUMMYPV:SP:RBV might be an alias).
-# 6) If DUMMYPV:SP exists on its own that is okay - it is probably a push button who's status cannot be read, but it should have a SP:RBV alias for DUMMYPV
+# 5) If DUMMYPV and DUMMYPV:SP exists then DUMMYPV:SP:RBV should exist too
+# (DUMMYPV:SP:RBV might be an alias).
+# 6) If DUMMYPV:SP exists on its own that is okay - it is probably a push button
+# who's status cannot be read, but it should have a SP:RBV alias for DUMMYPV
 # 7) If DUMMYPV exists on its own it is okay (represents a read-only parameter)
 # 8) Underscores:
 #        a) Allowed if used for making a name clearer, e.g. X_POSITION
-#        b) Not allowed to use the underscore instead of a ':', e.g. DUMMYPV_SP_RB
+#        b) Not allowed to use the underscore instead of a ':',
+#        e.g. DUMMYPV_SP_RB
+
 
 class DbChecker:
     def __init__(self, filename, debug=False):
@@ -23,11 +27,11 @@ class DbChecker:
         self.debug = debug
         
     def check(self):
-        print ("\n** CHECKING", self.file, "**")
+        print("\n** CHECKING", self.file, "**")
         records = parse_db(self.file)
         grouper = Grouper()
         
-        #Check for consistancy in whether PV macros are followed by colons
+        # Check for consistency in whether PV macros are followed by colons
         colon = None
         for r in records.keys():
             if colon is None:
@@ -37,15 +41,21 @@ class DbChecker:
                 n = self.remove_macro(r, False)
                 if n.startswith(':') != colon:
                     if colon:
-                        self.errors.append("FORMAT ERROR: " + r + " should have a colon after the macro")
+                        self.errors.append(
+                            "FORMAT ERROR: " + r +
+                            " should have a colon after the macro"
+                        )
                     else:
-                        self.errors.append("FORMAT ERROR: " + r + " should not have a colon after the macro")
+                        self.errors.append(
+                            "FORMAT ERROR: " + r +
+                            " should not have a colon after the macro"
+                        )
         
         groups = grouper.group_records(records)
         
         if self.debug:
             for s in groups.keys():
-                print (s, groups[s].RB, groups[s].SP, groups[s].SP_RBV)
+                print(s, groups[s].RB, groups[s].SP, groups[s].SP_RBV)
         
         for s in groups.keys():
             self.check_case(groups[s])
@@ -53,19 +63,19 @@ class DbChecker:
             self.check_candidates(groups[s], records)
                 
         for w in self.warnings:
-            print (w)
+            print(w)
                     
         for e in self.errors:
-            print (e)
+            print(e)
                                 
-        print ("** WARNING COUNT =", len(self.warnings), "**")
-        print ("** ERROR COUNT =", len(self.errors), "**")
+        print("** WARNING COUNT =", len(self.warnings), "**")
+        print("** ERROR COUNT =", len(self.errors), "**")
         
     def remove_macro(self, pvname, remove_colon=True):
         if pvname.find('$') != -1:
             left = pvname.rfind(')') + 1
             pvname = pvname[left:]
-            #Remove leading : if there is one
+            # Remove leading : if there is one
             if remove_colon and pvname.startswith(':'):
                 pvname = pvname[1:]
         return pvname
@@ -74,7 +84,9 @@ class DbChecker:
         def check(name):
             se = re.search('[a-z]', name)
             if not se is None:
-                self.errors.append("CASING ERROR: " + name + " should be upper-case")
+                self.errors.append(
+                    "CASING ERROR: " + name + " should be upper-case"
+                )
         check(group.RB)
         check(group.SP)
         check(group.SP_RBV)
@@ -82,45 +94,70 @@ class DbChecker:
     def check_chars(self, group):
         def check(name):
             name = self.remove_macro(name)            
-            #Only contains a-z A-Z 0-9 _ :
-            se = re.search('[^\w_:]', name)
-            if not se is None:
-                self.errors.append("CHARACTER ERROR: " + name + " contains illegal characters")
+            # Only contains a-z A-Z 0-9 _ :
+            se = re.search(r'[^\w_:]', name)
+            if se is not None:
+                self.errors.append(
+                    "CHARACTER ERROR: " + name + " contains illegal characters"
+                )
         check(group.RB)
         check(group.SP)
         check(group.SP_RBV)
             
     def check_candidates(self, group, records):  
-        ma1 = re.match("(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)$", group.main)
-        ma2 = re.match("(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$", group.main)
-        #print group.main, group.RB, group.SP, group.SP_RBV
-        if not ma1 is None:
-            #It is a SP, so it should have a readback alias (rule 6)
+        ma1 = re.match(r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)$", group.main)
+        ma2 = re.match(
+            r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$",
+            group.main
+        )
+        # print group.main, group.RB, group.SP, group.SP_RBV
+        if ma1 is not None:
+            # It is a SP, so it should have a readback alias (rule 6)
             if group.RB == '':
-                self.errors.append("FORMAT ERROR: " + group.SP + " does not have a correctly named readback alias")
+                self.errors.append(
+                    "FORMAT ERROR: " + group.SP +
+                    " does not have a correctly named readback alias"
+                )
             elif group.RB != '' and isinstance(records[group.RB], Alias):
-                #This is okay
+                # This is okay
                 return
             else:
-                self.errors.append("UNSPECIFIED ERROR: " + group.SP + " is not correct, please see the rules")      
-        elif not ma2 is None:
-            self.errors.append("FORMAT ERROR: cannot have a SP:RBV on its own (%s)" % (group.SP) )
+                self.errors.append(
+                    "UNSPECIFIED ERROR: " + group.SP +
+                    " is not correct, please see the rules"
+                )
+        elif ma2 is not None:
+            self.errors.append(
+                "FORMAT ERROR: cannot have a SP:RBV "
+                "on its own ({})".format(group.SP)
+            )
         else:
-            #Is a standard readback
+            # Is a standard readback
             if group.RB != '' and group.SP == '' and group.SP_RBV == '':
-                #This is okay as it represents a read-only value (rule 7)
+                # This is okay as it represents a read-only value (rule 7)
                 return
             else:
-                #Does it have SP:RBV but no SP - wrong
+                # Does it have SP:RBV but no SP - wrong
                 if group.SP == "" and group.SP_RBV != '':
-                    self.errors.append("PARAMETER ERROR: " + group.RB + " does not have a :SP")
+                    self.errors.append(
+                        "PARAMETER ERROR: " + group.RB + " does not have a :SP"
+                    )
                     return
-                #If a group has a SP then it should have a SP:RBV (rule 5)
+                # If a group has a SP then it should have a SP:RBV (rule 5)
                 if group.SP != "" and group.SP_RBV == "":
-                    self.errors.append("PARAMETER ERROR: " + group.RB + " has a :SP but not a :SP:RBV")
+                    self.errors.append(
+                        "PARAMETER ERROR: " + group.RB +
+                        " has a :SP but not a :SP:RBV"
+                    )
                     
-                #Finally check the format of the SP and SP:RBV (rule 4)
+                # Finally check the format of the SP and SP:RBV (rule 4)
                 if group.SP != "" and not group.SP.endswith(':SP'):
-                    self.errors.append("FORMAT ERROR: " + group.RB + " does not have a correctly formatted :SP")
+                    self.errors.append(
+                        "FORMAT ERROR: " + group.RB +
+                        " does not have a correctly formatted :SP"
+                    )
                 if group.SP_RBV != "" and not group.SP_RBV.endswith(':SP:RBV'):
-                    self.errors.append("FORMAT ERROR: " + group.RB + " does not have a correctly formatted :SP:RBV")    
+                    self.errors.append(
+                        "FORMAT ERROR: " + group.RB +
+                        " does not have a correctly formatted :SP:RBV"
+                    )

--- a/db_parser.py
+++ b/db_parser.py
@@ -84,7 +84,6 @@ def parse_db(filename):
             else:
                 if pv_name_match is not None:
                     # Found start of record
-                    # print "PV", pv_name_match.groups()[1]
                     record = Record(
                         pv_name_match.groups()[1], pv_name_match.groups()[0]
                     )
@@ -95,7 +94,6 @@ def parse_db(filename):
                         records[record.name] = record
 
                 elif not (alias_match is None):
-                    # print "Alias", alias_match.groups()[1]
                     alias = Alias(
                         alias_match.groups()[1], parent=alias_match.groups()[0]
                     )

--- a/db_parser.py
+++ b/db_parser.py
@@ -21,8 +21,7 @@ def parse_db(filename):
     # but this is not relevant at this level
     reg_record_start = r'record\s*\((\w+),\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
     # Aliases look like alias("RECORDNAME","ALIASNAME")
-    reg_alias_alone = r'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)",' \
-                      r'\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
+    reg_alias_alone = r'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)",\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
     
     with open(filename, 'r') as f:
     

--- a/db_parser.py
+++ b/db_parser.py
@@ -41,28 +41,22 @@ def parse_db(filename):
                     records[record.name] = record
                 else:
                     # Look for alias
-                    regex_alias_inside = r'alias\s*\(\s*"([\w_\-\:\[\]' \
-                                         r'<>;$\(\)]+)"\)'
+                    regex_alias_inside = r'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
                     ma_alias_inside = re.match(regex_alias_inside, line)
                     # Look for SIML
-                    reg_siml = r'\s+field\s*\(SIML,\s*"' \
-                               r'([\w_\-\:\[\]<>;$\(\)]+)"\)'
+                    reg_siml = r'\s+field\s*\(SIML,\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
                     ma_siml = re.match(reg_siml, line)
                     # Look for SDIS
-                    reg_sdis = r'\s+field\s*\(SDIS,\s*"' \
-                               r'([\w_\-\:\[\]<>;$\(\)]+)"\)'
+                    reg_sdis = r'\s+field\s*\(SDIS,\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
                     ma_sdis = re.match(reg_sdis, line)
                     # Look for DTYP
-                    reg_dtyp = r'\s+field\s*\(DTYP,\s*"' \
-                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    reg_dtyp = r'\s+field\s*\(DTYP,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
                     ma_dtyp = re.match(reg_dtyp, line)
                     # Look for NELM
-                    reg_nelm = r'\s+field\s*\(NELM,\s*"' \
-                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    reg_nelm = r'\s+field\s*\(NELM,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
                     ma_nelm = re.match(reg_nelm, line)
                     # Look for FTVL
-                    reg_ftvl = r'\s+field\s*\(FTVL,\s*"' \
-                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    reg_ftvl = r'\s+field\s*\(FTVL,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
                     ma_ftvl = re.match(reg_ftvl, line)
 
                     if not (ma_alias_inside is None):
@@ -98,5 +92,4 @@ def parse_db(filename):
                         alias_match.groups()[1], parent=alias_match.groups()[0]
                     )
                     records[alias_match.groups()[1]] = alias
-    
     return records

--- a/db_parser.py
+++ b/db_parser.py
@@ -15,76 +15,90 @@ def parse_db(filename):
 
     """
 
-    # This regex matches the EPICS convention for PV names, e.g. a-z A-Z 0-9 _ - : [ ] < > ;
-    # The ISIS convention uses a reduced set (a-z A-Z 0-9 _ :) but this is not relevant at this level
-    reg_record_start = 'record\s*\((\w+),\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
+    # This regex matches the EPICS convention for PV names,
+    # e.g. a-z A-Z 0-9 _ - : [ ] < > ;
+    # The ISIS convention uses a reduced set (a-z A-Z 0-9 _ :)
+    # but this is not relevant at this level
+    reg_record_start = r'record\s*\((\w+),\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
     # Aliases look like alias("RECORDNAME","ALIASNAME")
-    reg_alias_alone = 'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)",\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
+    reg_alias_alone = r'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)",' \
+                      r'\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
     
-    f = open(filename, 'r')
+    with open(filename, 'r') as f:
     
-    records = {}
-    inrecord = False
-    record = None
-    
-    for line in f:
-        pv_name_match = re.match(reg_record_start, line)
-        alias_match = re.match(reg_alias_alone, line)
-        
-        if inrecord:
-            record_end_match = re.match("}$", line.strip())
-            if not (record_end_match is None):
-                inrecord = False
-                records[record.name] = record
-            else:
-                # Look for alias
-                regex_alias_inside = 'alias\s*\(\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
-                ma_alias_inside = re.match(regex_alias_inside, line)
-                # Look for SIML
-                reg_siml = '\s+field\s*\(SIML,\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
-                ma_siml = re.match(reg_siml, line)
-                # Look for SDIS
-                reg_sdis = '\s+field\s*\(SDIS,\s*"([\w_\-\:\[\]<>;$\(\)]+)"\)'
-                ma_sdis = re.match(reg_sdis, line)
-                # Look for DTYP
-                reg_dtyp = '\s+field\s*\(DTYP,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
-                ma_dtyp = re.match(reg_dtyp, line)
-                # Look for NELM
-                reg_nelm = '\s+field\s*\(NELM,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
-                ma_nelm = re.match(reg_nelm, line)
-                # Look for FTVL
-                reg_ftvl = '\s+field\s*\(FTVL,\s*"([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
-                ma_ftvl = re.match(reg_ftvl, line)
-                
-                if not (ma_alias_inside is None):
-                    # There is an alias
-                    record.alias = Alias(ma_alias_inside.groups()[0], record.type, record.name)
-                if not (ma_siml is None):
-                    record.siml = ma_siml.groups()[0]
-                if not (ma_sdis is None):
-                    record.sdis = ma_sdis.groups()[0]
-                if not (ma_dtyp is None):
-                    record.dtyp = ma_dtyp.groups()[0]
-                if not (ma_nelm is None):
-                    record.nelm = ma_nelm.groups()[0]
-                if not (ma_ftvl is None):
-                    record.ftvl = ma_ftvl.groups()[0]
-        else:
-            if pv_name_match is not None:
-                # Found start of record
-                # print "PV", pv_name_match.groups()[1]
-                record = Record(pv_name_match.groups()[1], pv_name_match.groups()[0])
-                # check record doesn't start and stop on this line
-                if re.match(".*{.*}", line) is None:
-                    inrecord = True
-                else:
+        records = {}
+        inrecord = False
+        record = None
+
+        for line in f:
+            pv_name_match = re.match(reg_record_start, line)
+            alias_match = re.match(reg_alias_alone, line)
+
+            if inrecord:
+                record_end_match = re.match("}$", line.strip())
+                if not (record_end_match is None):
+                    inrecord = False
                     records[record.name] = record
+                else:
+                    # Look for alias
+                    regex_alias_inside = r'alias\s*\(\s*"([\w_\-\:\[\]' \
+                                         r'<>;$\(\)]+)"\)'
+                    ma_alias_inside = re.match(regex_alias_inside, line)
+                    # Look for SIML
+                    reg_siml = r'\s+field\s*\(SIML,\s*"' \
+                               r'([\w_\-\:\[\]<>;$\(\)]+)"\)'
+                    ma_siml = re.match(reg_siml, line)
+                    # Look for SDIS
+                    reg_sdis = r'\s+field\s*\(SDIS,\s*"' \
+                               r'([\w_\-\:\[\]<>;$\(\)]+)"\)'
+                    ma_sdis = re.match(reg_sdis, line)
+                    # Look for DTYP
+                    reg_dtyp = r'\s+field\s*\(DTYP,\s*"' \
+                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    ma_dtyp = re.match(reg_dtyp, line)
+                    # Look for NELM
+                    reg_nelm = r'\s+field\s*\(NELM,\s*"' \
+                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    ma_nelm = re.match(reg_nelm, line)
+                    # Look for FTVL
+                    reg_ftvl = r'\s+field\s*\(FTVL,\s*"' \
+                               r'([\w_\-\:\[\]<>;$\(\)\s]+)"\)'
+                    ma_ftvl = re.match(reg_ftvl, line)
 
-            elif not (alias_match is None):
-                # print "Alias", alias_match.groups()[1]
-                alias = Alias(alias_match.groups()[1], parent=alias_match.groups()[0])
-                records[alias_match.groups()[1]] = alias
+                    if not (ma_alias_inside is None):
+                        # There is an alias
+                        record.alias = Alias(
+                            ma_alias_inside.groups()[0], record.type,
+                            record.name
+                        )
+                    if not (ma_siml is None):
+                        record.siml = ma_siml.groups()[0]
+                    if not (ma_sdis is None):
+                        record.sdis = ma_sdis.groups()[0]
+                    if not (ma_dtyp is None):
+                        record.dtyp = ma_dtyp.groups()[0]
+                    if not (ma_nelm is None):
+                        record.nelm = ma_nelm.groups()[0]
+                    if not (ma_ftvl is None):
+                        record.ftvl = ma_ftvl.groups()[0]
+            else:
+                if pv_name_match is not None:
+                    # Found start of record
+                    # print "PV", pv_name_match.groups()[1]
+                    record = Record(
+                        pv_name_match.groups()[1], pv_name_match.groups()[0]
+                    )
+                    # check record doesn't start and stop on this line
+                    if re.match(r".*{.*}", line) is None:
+                        inrecord = True
+                    else:
+                        records[record.name] = record
 
-    f.close()
+                elif not (alias_match is None):
+                    # print "Alias", alias_match.groups()[1]
+                    alias = Alias(
+                        alias_match.groups()[1], parent=alias_match.groups()[0]
+                    )
+                    records[alias_match.groups()[1]] = alias
     
     return records

--- a/grouper.py
+++ b/grouper.py
@@ -30,8 +30,7 @@ class Grouper:
             # Stems are pure records, not aliases
             if isinstance(records[name], Record):
                 ma1 = re.match(
-                    r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)"
-                    r"[_:](RBV|RB|READBACK|READ)$", name
+                    r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$", name
                 )
                 ma2 = re.match(r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)$", name)
                 if ma1 is None and ma2 is None:
@@ -67,8 +66,7 @@ class Grouper:
                     name
                 )
                 ma2 = re.search(
-                    "^" + re.escape(s) + r"[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:]"
-                                         r"(RBV|RB|READBACK|READ)$",
+                    "^" + re.escape(s) + r"[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$",
                     name
                 )
                 

--- a/grouper.py
+++ b/grouper.py
@@ -1,13 +1,15 @@
 import re
 from records import Record
 
+
 class RecordGroup:
     def __init__(self, stem, main):
         self.stem = stem
-        self.main = main #The first non-alias PV found
+        self.main = main  # The first non-alias PV found
         self.RB = ""
         self.SP = ""
         self.SP_RBV = ""
+
 
 class Grouper:
     """A class for grouping related PVs together.
@@ -17,25 +19,29 @@ class Grouper:
         pass
         
     def group_records(self, records, debug=False):
-        #Get the record keys as a list because by sorting it we can identify stems easily 
+        # Get the record keys as a list because by
+        # sorting it we can identify stems easily
         names = sorted(records.keys())
         
         record_groups = {}
         
-        #Find potential stems
+        # Find potential stems
         for name in names:
-            #Stems are pure records, not aliases
+            # Stems are pure records, not aliases
             if isinstance(records[name], Record):
-                ma1 = re.match("(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$", name)
-                ma2 = re.match("(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)$", name)
+                ma1 = re.match(
+                    r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)"
+                    r"[_:](RBV|RB|READBACK|READ)$", name
+                )
+                ma2 = re.match(r"(.+)[_:](SP|SETPOINT|SETP|SEP|SETPT)$", name)
                 if ma1 is None and ma2 is None:
-                    #Something like DUMMYPV would get here
+                    # Something like DUMMYPV would get here
                     if not (name in record_groups.keys()):
                         record_groups[name] = RecordGroup(name, name)
                         record_groups[name].RB = name
                         continue
                 else:
-                    #Something like DUMMYPV:SP or DUMMYPV:SP:RBV would get here
+                    # Something like DUMMYPV:SP or DUMMYPV:SP:RBV would get here
                     if not (ma1 is None):
                         s = ma1.groups()[0]
                         if not (s in record_groups.keys()):
@@ -49,19 +55,26 @@ class Grouper:
                             record_groups[s].SP = name
                             continue         
 
-        #Now find the related names
+        # Now find the related names
         for name in names:
             for s in record_groups.keys():
-                #Don't readd the first name
+                # Don't readd the first name
                 if name == record_groups[s].main:
                     continue
                 
-                ma1 = re.search("^" + re.escape(s) + "[_:](SP|SETPOINT|SETP|SEP|SETPT)$", name)
-                ma2 = re.search("^" + re.escape(s) + "[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:](RBV|RB|READBACK|READ)$", name)
+                ma1 = re.search(
+                    "^" + re.escape(s) + r"[_:](SP|SETPOINT|SETP|SEP|SETPT)$",
+                    name
+                )
+                ma2 = re.search(
+                    "^" + re.escape(s) + r"[_:](SP|SETPOINT|SETP|SEP|SETPT)[_:]"
+                                         r"(RBV|RB|READBACK|READ)$",
+                    name
+                )
                 
-                if not ma1 is None:
+                if ma1 is not None:
                     record_groups[s].SP = name
-                elif not ma2 is None:
+                elif ma2 is not None:
                     record_groups[s].SP_RBV = name
                 elif s == name:
                     record_groups[s].RB = name
@@ -69,12 +82,16 @@ class Grouper:
         if debug:
             print("GROUPS:")
             for s in record_groups.keys():
-                print(s + record_groups[s].RB + record_groups[s].SP + record_groups[s].SP_RBV)
+                print(
+                    s + record_groups[s].RB + record_groups[s].SP +
+                    record_groups[s].SP_RBV
+                )
         
         return record_groups
-        
+
+
 if __name__ == '__main__':  
-    #Simple test
+    # Simple test
     from db_parser import parse_db
     testfile = "./add_sim_records_tests/test_db.db"
     r = parse_db(testfile)

--- a/records.py
+++ b/records.py
@@ -7,8 +7,8 @@ class Record:
         self.siml = None
         self.sdis = None
         self.dtyp = None
-        self.nelm = None #waveform only
-        self.ftvl = None #waveform only
+        self.nelm = None  # waveform only
+        self.ftvl = None  # waveform only
 
 
 class Alias:


### PR DESCRIPTION
Convert the DbChecker to be able to run in Python 3.

Mostly changes to become Pep8 compliant.

Removal of unused imports.

Fix logical error where pvname does not exist (add_sim_records.py function: get_sim_name).

print statement fixes.