### PR TITLE
Ticket8297 remove six usage

### DIFF
--- a/check_db_file_test.py
+++ b/check_db_file_test.py
@@ -50,7 +50,7 @@ class TestWithDBExamples(unittest.TestCase):
 
     def test_pv_all(self):
         filepath = join(self.test_folder, "test_all.db")
-        self.run_pv_check(filepath, [], [])
+        self.run_pv_check(filepath, [], ['Missing description on SHOULDFAIL:NODESC', "Invalid unit 'BADUNIT' on SHOULDFAIL:BADUNIT", 'Description too long on SHOULDFAIL:LONGDESC', 'Missing ASG on SHOULDFAIL:CALCNOREADONLY', 'Missing units on SHOULDFAIL:NOUNITS', 'Multiple instances of fields EGU on SHOULDFAIL:DUPLICATE:EGU', 'Multiple instances of fields PINI on SHOULDFAIL:DUPLICATE:PINI'])
 
     def test_pv_log_info(self):
         filepath = join(self.test_folder, "test_log_info_errors.db")
@@ -64,7 +64,20 @@ class TestWithDBExamples(unittest.TestCase):
 
     def test_pv_units(self):
         filepath = join(self.test_folder, "test_units.db")
-        self.run_pv_check(filepath, [], [])
+        self.run_pv_check(filepath, [], ["Invalid unit 'bit kbyte^-1' on SHOULDFAIL:BITS_KBYTE^-1",
+                                         "Invalid unit 'm^-1' on SHOULDFAIL:M-1",
+                                         "Invalid unit 'm s^-1' on SHOULDFAIL:m_S-1",
+                                         "Invalid unit 'kkm' on SHOULDFAIL:BADUNIT:KKM",
+                                         "Invalid unit 'kmk' on SHOULDFAIL:BADUNIT:KMK",
+                                         "Invalid unit 'k/(m s)' on SHOULDFAIL:BADUNIT:KM-1_S-1",
+                                         "Invalid unit 'm/(As)' on SHOULDFAIL:BADUNIT:MA-1S-1",
+                                        "Invalid unit 'dm' on SHOULDFAIL:BADUNIT:DM",
+                                        "Invalid unit 'kM' on SHOULDFAIL:BADUNIT:CAPS",
+                                        "Invalid unit 'Km' on SHOULDFAIL:BADUNIT:CAPS_2",
+                                        "Invalid unit '1' on SHOULDFAIL:BADUNIT:1",
+                                        "Invalid unit 'm^-2' on SHOULDFAIL:BADUNIT:negative_square_power",
+                                        "Invalid unit 'm^-1' on SHOULDFAIL:BADUNIT:negative_power"])
+
 
     def run_syntax_check(self, filepath, expected_warnings, expected_errors):
         self.maxDiff = 1500

--- a/src/db_parser/lexer.py
+++ b/src/db_parser/lexer.py
@@ -1,5 +1,4 @@
 import re
-import six
 from collections import OrderedDict
 
 from src.db_parser.tokens import TokenTypes
@@ -42,7 +41,7 @@ def _escape(var):
     return f"({re.escape(var)})"
 
 
-class Lexer(six.Iterator):
+class Lexer():
     """
     Lexer, tokenises the database file into
     """

--- a/src/db_parser/parser.py
+++ b/src/db_parser/parser.py
@@ -1,4 +1,3 @@
-import six
 from contextlib import contextmanager
 
 from src.db_parser.tokens import TokenTypes
@@ -22,7 +21,7 @@ class Parser(object):
         """
         try:
             # Ignore macros and comments wherever they occur
-            self.current_token = six.advance_iterator(self.lexer)
+            self.current_token = next(self.lexer)
         except StopIteration:
             self.raise_error("Next token was requested, but none exists.")
 

--- a/src/db_parser/tests/test_lexer.py
+++ b/src/db_parser/tests/test_lexer.py
@@ -1,7 +1,5 @@
 import unittest
 
-import six
-
 from src.db_parser.common import DbSyntaxError
 from src.db_parser.lexer import Lexer, Token
 from src.db_parser.tokens import TokenTypes
@@ -11,7 +9,7 @@ def get_tokens_list(lexer):
     tokens = []
     while True:
         try:
-            tokens.append(six.advance_iterator(lexer))
+            tokens.append(next(lexer))
         except StopIteration:
             break
     return tokens

--- a/src/db_parser/tests/test_parser.py
+++ b/src/db_parser/tests/test_parser.py
@@ -1,14 +1,12 @@
 import unittest
 
-import six
-
 from src.db_parser.common import DbSyntaxError
 from src.db_parser.lexer import Token
 from src.db_parser.parser import Parser
 from src.db_parser.tokens import TokenTypes
 
 
-class MockLexer(six.Iterator):
+class MockLexer():
     """
     Mocked lexer builder.
     """


### PR DESCRIPTION
### Description of work
Fix minor broken tests on master and then Remove all references to Six

### To test
[Ticket](https://github.com/ISISComputingGroup/IBEX/issues/8297)

### Acceptance criteria

- [x] Git grep finds no `import six`.
- [ ] Tests pass