### PR TITLE
Ignore isisdae.db

### DIFF
--- a/check_db_file.py
+++ b/check_db_file.py
@@ -61,6 +61,7 @@ DIRECTORIES_TO_ALWAYS_IGNORE = [
     "settings_xml.db",  # Uses EPICS 7 JSON syntax which is not yet supported in the parser
     "testParseJSON.db",  # Uses EPICS 7 JSON syntax which is not yet supported in the parser
     "Lakeshore340.db",  # Uses EPICS 7 JSON syntax which is not yet supported in the parser
+    "isisdae.db",  # Uses EPICS 7 JSON syntax which is not yet supported in the parser
     "site-packages",  # Don't look inside site-packages dirs
 ]
 


### PR DESCRIPTION
Started writing support for actually parsing json syntax properly on another branch, but this is the smaller change needed to get builds green